### PR TITLE
A bug fix in mongoimport path

### DIFF
--- a/db/seed.sh
+++ b/db/seed.sh
@@ -1,2 +1,2 @@
-mongoimport --db blog --collection users --file ./db/users.json --jsonArray
-mongoimport --db blog --collection articles --file ./db/articles.json --jsonArray
+mongoimport --db blog --collection users --file ./users.json --jsonArray
+mongoimport --db blog --collection articles --file ./articles.json --jsonArray


### PR DESCRIPTION
Changed the contents of /db/seed.sh file from 

```
mongoimport --db blog --collection users --file ./db/users.json --jsonArray
mongoimport --db blog --collection articles --file ./db/articles.json --jsonArray
```

to

```
mongoimport --db blog --collection users --file ./users.json --jsonArray
mongoimport --db blog --collection articles --file ./articles.json --jsonArray
```

Just a simple change in path ,which was mentioned wrong and due to which mongoimport won't work.. 
A user was facing issue due to this problem.. https://github.com/azat-co/blog-express/issues/6
